### PR TITLE
Professurenbezeichnung ergänzt

### DIFF
--- a/kdsf.xsd
+++ b/kdsf.xsd
@@ -68,6 +68,8 @@
 									<xs:element name="Geschlecht" type="kdsf-basis:Geschlecht__Type"
 										minOccurs="0"/>
 									<xs:element ref="kdsf-basis:PersonalkategorieId" minOccurs="0"/>
+									<xs:element ref="kdsf-basis:ProfessurenbezeichnungId"
+										minOccurs="0"/>
 									<xs:element ref="kdsf-basis:FinanzierungsformId" minOccurs="0"/>
 									<xs:element name="QualifikationId" type="cf:cfId__Type"
 										minOccurs="0"/>
@@ -101,6 +103,8 @@
 									<xs:element name="Geschlecht" type="kdsf-basis:Geschlecht__Type"
 										minOccurs="0"/>
 									<xs:element ref="kdsf-basis:PersonalkategorieId" minOccurs="0"/>
+									<xs:element ref="kdsf-basis:ProfessurenbezeichnungId"
+										minOccurs="0"/>
 									<xs:element ref="kdsf-basis:FinanzierungsformId" minOccurs="0"/>
 									<xs:element name="QualifikationId" type="cf:cfId__Type"
 										minOccurs="0"/>


### PR DESCRIPTION
Ein Element für die Ausdifferenzierung Bezeichnung ([Be41](https://kerndatensatz-forschung.de/version1/spez_versionen/Spezifikationstabelle_KDSF_v1_3.html#Be41)) für die Personalkategorie Professuren wurde ergänzt. Vielen Dank an @jniesch für den Hinweis.